### PR TITLE
rgw/motr: fix concurrent obj puts

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -253,11 +253,10 @@ endif()
 
 if(WITH_RADOSGW_MOTR)
   target_include_directories(rgw_common PRIVATE "/usr/include/motr")
-  target_compile_options(rgw_common
-    PRIVATE "-Wno-attributes")
+  target_compile_options(rgw_common PRIVATE "-Wno-attributes")
   target_compile_definitions(rgw_common
     PRIVATE "M0_EXTERN=extern" "M0_INTERNAL=")
-  target_link_libraries(rgw_common PRIVATE "motr")
+  target_link_libraries(rgw_common PRIVATE motr motr-helpers)
 endif()
 
 set(rgw_a_srcs

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -24,6 +24,7 @@ extern "C" {
 #include "lib/types.h"
 #include "lib/trace.h"   // m0_trace_set_mmapped_buffer
 #include "motr/layout.h" // M0_OBJ_LAYOUT_ID
+#include "helpers/helpers.h" // m0_ufid_next
 }
 
 #include "common/Clock.h"
@@ -43,6 +44,7 @@ using std::set;
 using std::list;
 
 static string mp_ns = RGW_OBJ_NS_MULTIPART;
+static struct m0_ufid_generator ufid_gr;
 
 namespace rgw::sal {
 
@@ -1346,26 +1348,30 @@ void MotrObject::obj_name_to_motr_fid(struct m0_uint128 *obj_fid)
 int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 {
   if (mobj != nullptr) {
-    ldpp_dout(dpp, 0) << "ERROR: object is already opened" << dendl;
+    ldpp_dout(dpp, 0) << __func__ << "ERROR: object is already opened" << dendl;
     return -EINVAL;
   }
 
-  this->obj_name_to_motr_fid(&fid);
+  int rc = m0_ufid_next(&ufid_gr, 1, &meta.oid);
+  if (rc != 0) {
+    ldpp_dout(dpp, 0) << __func__ << "ERROR: m0_ufid_next() failed: " << rc << dendl;
+    return rc;
+  }
 
   char fid_str[M0_FID_STR_LEN];
-  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&fid));
-  ldpp_dout(dpp, 20) << __func__ << ": sz=" << sz << " fid=" << fid_str << dendl;
+  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
+  ldpp_dout(dpp, 20) << __func__ << ": sz=" << sz << " oid=" << fid_str << dendl;
 
   int64_t lid = m0_layout_find_by_objsz(store->instance, nullptr, sz);
   M0_ASSERT(lid > 0);
 
   M0_ASSERT(mobj == nullptr);
   mobj = new m0_obj();
-  m0_obj_init(mobj, &store->container.co_realm, &fid, lid);
+  m0_obj_init(mobj, &store->container.co_realm, &meta.oid, lid);
 
   struct m0_op *op = nullptr;
   mobj->ob_entity.en_flags |= M0_ENF_META;
-  int rc = m0_entity_create(nullptr, &mobj->ob_entity, &op);
+  rc = m0_entity_create(nullptr, &mobj->ob_entity, &op);
   if (rc != 0) {
     this->close_mobj();
     ldpp_dout(dpp, 0) << "ERROR: m0_entity_create() failed: " << rc << dendl;
@@ -1394,11 +1400,9 @@ int MotrObject::create_mobj(const DoutPrefixProvider *dpp, uint64_t sz)
 
 int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
 {
-  this->obj_name_to_motr_fid(&fid);
-
   char fid_str[M0_FID_STR_LEN];
-  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&fid));
-  ldpp_dout(dpp, 20) << __func__ << ": fid=" << fid_str << dendl;
+  snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&meta.oid));
+  ldpp_dout(dpp, 20) << __func__ << ": oid=" << fid_str << dendl;
 
   int rc;
   if (meta.layout_id == 0) {
@@ -1414,7 +1418,7 @@ int MotrObject::open_mobj(const DoutPrefixProvider *dpp)
   M0_ASSERT(mobj == nullptr);
   mobj = new m0_obj();
   memset(mobj, 0, sizeof *mobj);
-  m0_obj_init(mobj, &store->container.co_realm, &fid, store->conf.mc_layout_id);
+  m0_obj_init(mobj, &store->container.co_realm, &meta.oid, store->conf.mc_layout_id);
 
   struct m0_op *op = nullptr;
   mobj->ob_attr.oa_layout_id = meta.layout_id;
@@ -1640,7 +1644,7 @@ int MotrObject::get_bucket_dir_ent(const DoutPrefixProvider *dpp, rgw_bucket_dir
       if (ent_to_check.is_current()) {
         ent = ent_to_check;
         rc = 0;
-	goto out;
+        goto out;
       }
     }
 
@@ -1967,7 +1971,7 @@ int MotrAtomicWriter::write()
       rc = obj.open_mobj(dpp);
     if (rc != 0) {
       char fid_str[M0_FID_STR_LEN];
-      snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&obj.fid));
+      snprintf(fid_str, ARRAY_SIZE(fid_str), U128X_F, U128_P(&obj.meta.oid));
       ldpp_dout(dpp, 0) << "ERROR: failed to create/open motr object "
                         << fid_str << " (" << obj.get_bucket()->get_name()
                         << "/" << obj.get_key().to_str() << "): rc=" << rc
@@ -2059,6 +2063,9 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   if (rc != 0)
     return rc;
 
+  // TODO: add key:user+bucket+key+obj.meta.oid value:timestamp to
+  // gc.queue.index. See more at github.com/Seagate/cortx-rgw/issues/7.
+
   bufferlist bl;
   rgw_bucket_dir_entry ent;
 
@@ -2124,7 +2131,7 @@ int MotrAtomicWriter::complete(size_t accounted_size, const std::string& etag,
   // Insert an entry into bucket index.
   string bucket_index_iname = "motr.rgw.bucket.index." + obj.get_bucket()->get_name();
   rc = store->do_idx_op_by_name(bucket_index_iname,
-                                M0_IC_PUT, obj.get_key().to_str(), bl);
+                                M0_IC_PUT, obj.get_key().to_str(), bl, false);
   if (rc == 0)
     store->get_obj_meta_cache()->put(dpp, obj.get_key().to_str(), bl);
 
@@ -2556,7 +2563,7 @@ int MotrMultipartUpload::complete(const DoutPrefixProvider *dpp,
   ldpp_dout(dpp, 20) << "MotrMultipartUpload::complete(): target_obj name=" << target_obj->get_name()
                                   << " target_obj oid=" << target_obj->get_oid() << dendl;
   rc = store->do_idx_op_by_name(bucket_index_iname, M0_IC_PUT,
-                                target_obj->get_name(), update_bl);
+                                target_obj->get_name(), update_bl, false);
   if (rc < 0)
     return rc;
 
@@ -3315,7 +3322,7 @@ void MotrStore::index_name_to_motr_fid(string iname, struct m0_uint128 *id)
 }
 
 int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
-                                 string key_str, bufferlist &bl)
+                                 string key_str, bufferlist &bl, bool update)
 {
   struct m0_idx idx;
   vector<uint8_t> key(key_str.begin(), key_str.end());
@@ -3335,7 +3342,7 @@ int MotrStore::do_idx_op_by_name(string idx_name, enum m0_idx_opcode opcode,
   ldout(cctx, 20) << "DEBUG: do_idx_op_by_name(): op="
                  << (opcode == M0_IC_PUT ? "PUT" : "GET")
                  << " idx=" << idx_name << " key=" << key_str << dendl;
-  rc = do_idx_op(&idx, opcode, key, val, true);
+  rc = do_idx_op(&idx, opcode, key, val, update);
   if (rc == 0 && opcode == M0_IC_GET)
     // Append the returned value (blob) to the bufferlist.
     bl.append(reinterpret_cast<char*>(val.data()), val.size());
@@ -3467,6 +3474,12 @@ void *newMotrStore(CephContext *cct)
     rc = store->container.co_realm.re_entity.en_sm.sm_rc;
     if (rc != 0) {
       ldout(cct, 0) << "ERROR: m0_container_init() failed: " << rc << dendl;
+      goto out;
+    }
+
+    rc = m0_ufid_init(store->instance, &ufid_gr);
+    if (rc != 0) {
+      ldout(cct, 0) << "ERROR: m0_ufid_init() failed: " << rc << dendl;
       goto out;
     }
 

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -438,12 +438,15 @@ class MotrObject : public Object {
 
     // motr object metadata stored in index
     struct Meta {
+      struct m0_uint128 oid = {};
       struct m0_fid pver = {};
       uint64_t layout_id = 0;
 
       void encode(bufferlist& bl) const
       {
-        ENCODE_START(3, 3, bl);
+        ENCODE_START(5, 5, bl);
+        encode(oid.u_hi, bl);
+        encode(oid.u_lo, bl);
         encode(pver.f_container, bl);
         encode(pver.f_key, bl);
         encode(layout_id, bl);
@@ -452,7 +455,9 @@ class MotrObject : public Object {
 
       void decode(bufferlist::const_iterator& bl)
       {
-        DECODE_START(3, bl);
+        DECODE_START(5, bl);
+        decode(oid.u_hi, bl);
+        decode(oid.u_lo, bl);
         decode(pver.f_container, bl);
         decode(pver.f_key, bl);
         decode(layout_id, bl);
@@ -461,7 +466,6 @@ class MotrObject : public Object {
     };
 
     struct m0_obj     *mobj = NULL;
-    struct m0_uint128  fid;
     Meta               meta;
 
     struct MotrReadOp : public ReadOp {
@@ -952,7 +956,7 @@ class MotrStore : public Store {
     int create_motr_idx_by_name(std::string iname);
     int delete_motr_idx_by_name(std::string iname);
     int do_idx_op_by_name(std::string idx_name, enum m0_idx_opcode opcode,
-                          std::string key_str, bufferlist &bl);
+                          std::string key_str, bufferlist &bl, bool update=true);
     int check_n_create_global_indices();
 
     int init_metadata_cache(const DoutPrefixProvider *dpp, CephContext *cct);


### PR DESCRIPTION
Always generate new motr fid for objects, even for the same
S3 objects. This way even the same S3 object can be concurrently
written to motr. But only one of them is stored, for the other one
the error is returned, according to S3 API spec.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
